### PR TITLE
[FEATURE] Secrets management, https access to db & [FIX] Standarize siege wartimes

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,4 @@
+# MariaDB credentials
+DB_USER=l1j
+DB_PASSWORD=l1j
+DB_ROOT_PASSWORD=password

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ l1jen.jar
 .gradle
 .idea
 build
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ l1jen.jar
 /bin
 /log
 /emblem
+/certbot
 *.iml
 *.ipr
 *.iws

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ WORKDIR /l1j
 RUN ant
 
 #### Runtime
-FROM gcr.io/distroless/java:11
+FROM gcr.io/distroless/java11-debian11
 
 EXPOSE 2000
 

--- a/config/server.properties
+++ b/config/server.properties
@@ -36,7 +36,7 @@ NpcAIImplType = 2
 ClientHistoricalPacketCount = 500
 
 # Time For Your Country
-TimeZone = EST
+TimeZone = UTC
 
 # True, False
 HostnameLookups = False

--- a/docker-cert-renewal.sh
+++ b/docker-cert-renewal.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Run Certbot to renew certificates
+echo "Attempting to renew certificates..."
+docker compose run --rm certbot renew
+
+# Check if renewal was successful
+if [ $? -ne 0 ]; then
+    echo "Certbot renewal failed."
+else
+    echo "Certbot renewal successful. Reloading Nginx..."
+    docker compose kill -s HUP nginx
+    echo "Nginx reloaded."
+fi
+

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,11 +3,13 @@ services:
     image: mariadb:10.2
     container_name: l1j-db
     restart: always
+    env_file:
+      - .env
     environment:
       MYSQL_DATABASE: l1jdb
-      MYSQL_USER: l1j
-      MYSQL_PASSWORD: l1j
-      MYSQL_ROOT_PASSWORD: password
+      MYSQL_USER: ${DB_USER}
+      MYSQL_PASSWORD: ${DB_PASSWORD}
+      MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
     volumes:
       - my-db:/var/lib/mysql
       - ./db:/docker-entrypoint-initdb.d
@@ -18,12 +20,12 @@ services:
     image: phpmyadmin:latest
     container_name: l1j-phpmyadmin
     restart: always
+    env_file:
+      - .env
     ports:
       - "8081:80" # remove it if you use ssl to acces through nginx (more info in nginx.conf)
     environment:
       PMA_HOST: l1jdb
-      PMA_USER: l1j
-      PMA_PASSWORD: l1j
     depends_on:
       - l1jdb
     networks:
@@ -31,10 +33,14 @@ services:
 
   l1jserver:
     environment:
-     DB_HOST: "jdbc:mysql://l1jdb:3306/l1jdb?autoReconnect=true&useUnicode=True&characterEncoding=UTF-8"
+      DB_URL: "jdbc:mysql://l1jdb:3306/l1jdb?autoReconnect=true&useUnicode=True&characterEncoding=UTF-8"
+      DB_USER: ${DB_USER}
+      DB_PASSWORD: ${DB_PASSWORD}
     build: .
     container_name: l1j-server
     restart: always
+    env_file:
+      - .env
     volumes:
       - ./config:/l1j/config
     depends_on:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,7 +19,7 @@ services:
     container_name: l1j-phpmyadmin
     restart: always
     ports:
-      - "8081:80"
+      - "8081:80" # remove it if you use ssl to acces through nginx (more info in nginx.conf)
     environment:
       PMA_HOST: l1jdb
       PMA_USER: l1j
@@ -47,12 +47,25 @@ services:
     container_name: l1j-nginx
     restart: always
     ports:
-      - "8080:80"
+      - "80:80"
+      - "443:443"
       - "2000:2000"   # proxy login port
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./certbot/www:/var/www/certbot
+      - ./certbot/certs:/etc/letsencrypt
     depends_on:
       - l1jserver
+      - phpmyadmin
+    networks:
+      - l1jnet
+
+  certbot:
+    image: certbot/certbot
+    container_name: l1j-certbot
+    volumes:
+      - ./certbot/www:/var/www/certbot
+      - ./certbot/certs:/etc/letsencrypt
     networks:
       - l1jnet
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -25,11 +25,57 @@ stream {
 http {
     server {
         listen 80;
-        server_name localhost;
+        listen [::]:80;
+        # Replace with your domain if planning to use https
+        server_name localhost; 
 
+        # Required for certbot renewal
+        location /.well-known/acme-challenge/ {
+            root /var/www/certbot;
+        }
+
+        # Redirect all HTTP to HTTPS
         location / {
-            return 200 'NGINX is working';
-            add_header Content-Type text/plain;
+            return 301 https://$host$request_uri;
         }
     }
+
+    ### Request a Let's Encrypt certificate ###
+
+    # 1) In server/listen 80 section, replace localhost with your actual domain
+    # 2) Restart nginx (docker compose restart nginx) with: docker compose up -d nginx (make sure nginx is running without ssl first and without errors)
+    # 2) Run the command below to obtain the certificate
+    #       docker compose run --rm certbot certonly --webroot --webroot-path=/var/www/certbot -d yourdomain.com
+    # 3) Uncomment the ssl section below and replace <yourdomain> with your actual domain and restart nginx (docker compose restart nginx)
+    # 4) Set up a cron job to renew the certificate automatically (optional but recommended) 
+    #       docker-cert-renewal.sh is provided for this purpose
+
+    ### SSL configuration ###
+
+    # server {
+    #     listen 443 ssl;
+    #     listen [::]:443 ssl;
+    #     server_name <yourdomain>;
+
+    #     ssl_certificate /etc/letsencrypt/live/<yourdomain>/fullchain.pem;
+    #     ssl_certificate_key /etc/letsencrypt/live/<yourdomain>/privkey.pem;
+
+    #     # Add strong security headers (optional but recommended)
+    #     ssl_protocols TLSv1.3 TLSv1.2;
+    #     ssl_ciphers 'TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256';
+    #     ssl_prefer_server_ciphers off;
+    #     ssl_session_cache shared:SSL:10m;
+    #     ssl_session_timeout 1d;
+    #     ssl_session_tickets off;
+
+    #     # Replace this with your actual application's proxy settings
+    #     location / {
+    #         # e.g., proxy to another container running on port 3000
+    #         proxy_pass http://phpmyadmin:80;
+    #         proxy_set_header Host $host;
+    #         proxy_set_header X-Real-IP $remote_addr;
+    #         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    #         proxy_set_header X-Forwarded-Proto $scheme;
+    #     }
+    # }
 }

--- a/src/l1j/server/Config.java
+++ b/src/l1j/server/Config.java
@@ -615,11 +615,13 @@ public final class Config {
 					"GameserverPort", "2000"));
 			DB_DRIVER = serverSettings.getProperty("Driver",
 					"com.mysql.jdbc.Driver");
-			DB_URL = System.getenv().getOrDefault("DB_HOST", 
+			DB_URL = System.getenv().getOrDefault("DB_URL", 
 					serverSettings.getProperty("URL", 
 					"jdbc:mysql://localhost:3306/l1jdb?useUnicode=True&characterEncoding=UTF-8"));
-			DB_LOGIN = serverSettings.getProperty("Login", "root");
-			DB_PASSWORD = serverSettings.getProperty("Password", "");
+			DB_LOGIN = System.getenv().getOrDefault("DB_USER", 
+					serverSettings.getProperty("Login", "root"));
+			DB_PASSWORD = System.getenv().getOrDefault("DB_PASSWORD", 
+					serverSettings.getProperty("Password", ""));
 			PASSWORD_SALT = serverSettings.getProperty("PasswordSalt", "");
 			THREAD_P_TYPE_GENERAL = Integer.parseInt(
 					serverSettings.getProperty("GeneralThreadPoolType", "0"),

--- a/src/l1j/server/server/controllers/WarTimeController.java
+++ b/src/l1j/server/server/controllers/WarTimeController.java
@@ -55,7 +55,6 @@ public class WarTimeController implements Runnable {
 			Calendar nowTime = getRealTime();
 			Calendar oldTime = getRealTime();
 			oldTime.setTime(_l1castle[i].getWarTime().getTime());
-			_war_start_time[i] = _l1castle[i].getWarTime();
 			oldTime.add(Config.ALT_WAR_TIME_UNIT, Config.ALT_WAR_TIME);
 
 			if (CheckWarTime.getInstance().isActive(_l1castle[i].getId())

--- a/src/l1j/server/server/datatables/CastleTable.java
+++ b/src/l1j/server/server/datatables/CastleTable.java
@@ -26,11 +26,13 @@ import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Map;
+import java.util.TimeZone;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import l1j.server.Config;
 import l1j.server.L1DatabaseFactory;
 import l1j.server.server.templates.L1Castle;
 import l1j.server.server.utils.SQLUtil;
@@ -50,7 +52,8 @@ public class CastleTable {
 	}
 
 	private Calendar timestampToCalendar(Timestamp ts) {
-		Calendar cal = Calendar.getInstance();
+		TimeZone _tz = TimeZone.getTimeZone(Config.TIME_ZONE);		
+		Calendar cal = Calendar.getInstance(_tz);
 		cal.setTimeInMillis(ts.getTime());
 		return cal;
 	}


### PR DESCRIPTION
- Secrets managment using `.env` files
- Add Let's encrypt `ssl` certificates to enable `https` for phpmyadmin access to db.
- Standarize siege wartimes to ensure all timezones are consistent with server.properties `TimeZone`. By default use 'UTC'.